### PR TITLE
Add Jest test for sorting search results

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "module": "dist/plugin.min.js",
   "scripts": {
     "build": "rollup -c",
-    "watch": "rollup -cw"
+    "watch": "rollup -cw",
+    "test": "jest"
   },
   "dependencies": {
     "@crownframework/svelte-error-boundary": "^1.0.3",
@@ -17,6 +18,7 @@
     "@budibase/backend-core": "^2.0.13",
     "@rollup/plugin-commonjs": "^18.0.0",
     "@rollup/plugin-node-resolve": "^11.2.1",
+    "jest": "^29.7.0",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.2.10",
     "rollup": "^2.44.0",

--- a/src/searchHelper.js
+++ b/src/searchHelper.js
@@ -1,0 +1,15 @@
+async function searchAndMaybeSort(API, tableId, params, field, sort) {
+  const result = await API.searchTable(tableId, params);
+  let rows = result.rows || [];
+  if (sort) {
+    rows = [...rows].sort((a, b) => {
+      const aVal = String(a[field] ?? '').toLowerCase();
+      const bVal = String(b[field] ?? '').toLowerCase();
+      if (aVal < bVal) return -1;
+      if (aVal > bVal) return 1;
+      return 0;
+    });
+  }
+  return rows;
+}
+module.exports = { searchAndMaybeSort };

--- a/tests/sort.test.js
+++ b/tests/sort.test.js
@@ -1,0 +1,18 @@
+const { searchAndMaybeSort } = require('../src/searchHelper.js');
+
+const createAPI = (rows) => ({
+  searchTable: jest.fn().mockResolvedValue({ rows })
+});
+
+describe('searchAndMaybeSort', () => {
+  test('sorts results by field when sort is true', async () => {
+    const rows = [
+      { optionsTypeState: 'b', id: 1 },
+      { optionsTypeState: 'a', id: 2 }
+    ];
+    const API = createAPI(rows);
+    const result = await searchAndMaybeSort(API, 'table1', {}, 'optionsTypeState', true);
+    expect(API.searchTable).toHaveBeenCalled();
+    expect(result.map(r => r.optionsTypeState)).toEqual(['a', 'b']);
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest dev dependency and npm test script
- add helper for sorting search results
- test that search results are sorted when `sort` is true

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68405c4b9f34832bb0699e1260f2b9ad