### PR TITLE
Implement Frank user fun mode

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -25,6 +25,11 @@
         "key": "placeholder"
       },
       {
+        "type": "text",
+        "label": "User Name",
+        "key": "userName"
+      },
+      {
         "type": "select",
         "label": "Type",
         "key": "optionsType",

--- a/src/Component.svelte
+++ b/src/Component.svelte
@@ -25,6 +25,7 @@
   export let dataSource
   export let label;
   export let placeholder;
+  export let userName;
   export let defaultValue
   
   export let limitResults;
@@ -183,7 +184,7 @@
     }
   }
 </script>
-  <div class="spectrum-Form-item {labelPos === "above" ? "flexCol" : ""}" use:styleable={$component.styles}>
+  <div class="spectrum-Form-item {labelPos === "above" ? "flexCol" : ""} {userName === 'Frank' ? 'frank-mode' : ''}" use:styleable={$component.styles}>
     {#if !formContext}
       <div class="placeholder">Form components need to be wrapped in a form</div>
     {:else}
@@ -334,6 +335,18 @@
     width: 2.5rem;
     height: 2.5rem;
     border-width: 6px;
+  }
+  .frank-mode {
+    position: relative;
+    animation: frank-spin 2s linear infinite, frank-bounce 0.5s ease-in-out infinite alternate;
+  }
+  @keyframes frank-spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+  }
+  @keyframes frank-bounce {
+    from { left: 0; }
+    to { left: 10px; }
   }
   @keyframes spinner {
     0% { transform: rotate(0deg); }


### PR DESCRIPTION
## Summary
- add a new `userName` setting to schema
- export `userName` prop in `Component.svelte`
- apply `frank-mode` animation when `userName` is `Frank`
- define `frank-mode` styles

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684173095a28832b818dc920fbd5e984